### PR TITLE
Updated barcode api

### DIFF
--- a/src/Api/BarcodeApi.php
+++ b/src/Api/BarcodeApi.php
@@ -93,9 +93,10 @@ class BarcodeApi extends BaseClient
      *
      * @access public
      * @param string $destination
+     * @param string $range
      * @return string
      */
-    public function getBarcodeByDestination($destination = 'NL', $serie = null)
+    public function getBarcodeByDestination($destination = 'NL', $serie = null, $range = null)
     {
         $barcodeType = isset($this->countryBarcodeType[$destination]) ?
             $this->countryBarcodeType[$destination] :
@@ -104,7 +105,7 @@ class BarcodeApi extends BaseClient
             'NL' :
             (($barcodeType === self::BARCODE_TYPE_GLOBAL_PACK) ? 'GLOBAL' : 'EU');
         $serie = !is_null($serie) ? $serie : $this->detectSerie($serieDestination);
-        return $this->generateBarcode($barcodeType, $serie, ($destination === 'NL'));
+        return $this->generateBarcode($barcodeType, $serie, $range, ($destination === 'NL'));
     }
     
     /**
@@ -113,10 +114,11 @@ class BarcodeApi extends BaseClient
      * @access public
      * @param string $type
      * @param string $serie
+     * @param string $range
      * @param boolean $domestic = domestic (dutch) shipment
      * @return \Avido\PostNLCifClient\Response\SendTrack\Barcode\BarcodeResponse
      */
-    public function getBarcode($type, $serie = null, $domestic = true)
+    public function getBarcode($type, $serie = null, $range = null, $domestic = true)
     {
         if (!in_array($type, $this->availableBarcodeTypes)) {
             throw new InvalidBarcodeTypeException($type);
@@ -139,7 +141,7 @@ class BarcodeApi extends BaseClient
                     $serie = '0000-9999';
             }
         }
-        return $this->generateBarcode($type, $serie, $domestic);
+        return $this->generateBarcode($type, $serie, $range, $domestic);
     }
     
     /**
@@ -148,10 +150,11 @@ class BarcodeApi extends BaseClient
      * @access public
      * @param string $type
      * @param string $serie
+     * @param string $range
      * @param boolean $domestic = domestic (dutch) shipment
      * @return \Avido\PostNLCifClient\Response\SendTrack\Barcode\BarcodeResponse
      */
-    public function generateBarcode($type, $serie = null, $domestic = true)
+    public function generateBarcode($type, $serie = null, $range = null, $domestic = true)
     {
         if (!in_array($type, $this->availableBarcodeTypes)) {
             throw new InvalidBarcodeTypeException($type);
@@ -174,8 +177,11 @@ class BarcodeApi extends BaseClient
                     $serie = '0000-9999';
             }
         }
+        if (is_null($range)) {
+            $range = $this->getCustomerCode();
+        }
         $request = new BarcodeRequest();
-        $request->setCustomerCode($this->getCustomerCode())
+        $request->setCustomerCode($range)
             ->setCustomerNumber($this->getCustomerNumber())
             ->setType($type)
             ->setSerie($serie);

--- a/tests/CifApiTest.php
+++ b/tests/CifApiTest.php
@@ -536,7 +536,21 @@ class CifApiTest extends TestCase
         // Serie will be automatically detected based on $type and $domestic 
         $serie = null; 
         $domestic = true;
-        $response = $this->client->getAPI('barcode')->getBarcode($type, $serie, $domestic);
+        $response = $this->client->getAPI('barcode')->getBarcode($type, $serie, null, $domestic);
+        $this->assertNotNull($response->getBarcode());
+        return $response->getBarcode();
+    }
+    
+    /**
+     * Get Barcode Global Pack Test
+     *
+     * @group barcode
+     */
+    public function testBarcodeGlobalPack ()
+    {
+        $range = getenv('CUST_CODE_GLOBAL_PACK');
+        $type = 'CD';
+        $response = $this->client->getAPI('barcode')->getBarcode($type, null, $range, false);
         $this->assertNotNull($response->getBarcode());
         return $response->getBarcode();
     }
@@ -553,7 +567,7 @@ class CifApiTest extends TestCase
         $type = '3Sss'; // invalid type
         $serie = null; 
         $domestic = true;
-        $response = $this->client->getAPI('barcode')->getBarcode($type, $serie, $domestic);
+        $response = $this->client->getAPI('barcode')->getBarcode($type, $serie, null, $domestic);
     }
     
     /**
@@ -569,7 +583,7 @@ class CifApiTest extends TestCase
         $type = '3S';
         $serie = 0;
         $domestic = true;
-        $response = $this->client->getAPI('barcode')->getBarcode($type, $serie, $domestic);
+        $response = $this->client->getAPI('barcode')->getBarcode($type, $serie, null, $domestic);
     }
 
     /**


### PR DESCRIPTION
Added 'range' to request. In the soap webservices version this argument was called, "Range" in the rest version it's called (confusing) customerCode
